### PR TITLE
fix: define output explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,12 +176,14 @@ Supports null in JSON format.
 
 <!-- gha-outputs-start -->
 
-| ID           | Description                                                                                                                                                                          |
-| :----------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `continue`   | Indicates whether the IssueOps command was triggered and the workflow should continue with the string `"true"`. If the action did not complete successfully, `"false"` will be used. |
-| `params`     | The parameters of the triggered IssueOps command, provided as a JSON string.                                                                                                         |
-| `comment_id` | The ID of the comment that triggered this action.                                                                                                                                    |
-| `actor`      | The GitHub handle of the actor who executed the IssueOps command.                                                                                                                    |
+| ID             | Description                                                                                                                                                                          |
+| :------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `continue`     | Indicates whether the IssueOps command was triggered and the workflow should continue with the string `"true"`. If the action did not complete successfully, `"false"` will be used. |
+| `params`       | The parameters of the triggered IssueOps command, provided as a JSON string.                                                                                                         |
+| `comment_id`   | The ID of the comment that triggered this action.                                                                                                                                    |
+| `actor`        | The GitHub handle of the actor who executed the IssueOps command.                                                                                                                    |
+| `issue_number` | The issue number of the comment that triggered this action.                                                                                                                          |
+| `command`      | The command of the triggered IssueOps command.                                                                                                                                       |
 
 <!-- gha-outputs-end -->
 

--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,10 @@ outputs:
     description: 'The ID of the comment that triggered this action.'
   actor:
     description: 'The GitHub handle of the actor who executed the IssueOps command.'
+  issue_number:
+    description: 'The issue number of the comment that triggered this action.'
+  command:
+    description: 'The command of the triggered IssueOps command.'
 
 runs:
   using: 'node20'


### PR DESCRIPTION
`issue_number` and `command` were already emitted internally, but they weren’t declared in the `outputs` section of `action.yaml` , so I added explicit definitions for them.







