### PR TITLE
chore: add minimum permissions to workflows

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -6,6 +6,10 @@ on:
       - opened
       - synchronize
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

knowledge-work/knowledgework#116114 ("サプライチェーン対策: 既存 GitHub Actions の権限最小化") の対応漏れ。本リポジトリのワークフローに最小限の `permissions:` ブロックを追加します。

## Changes

| Workflow | Permissions |
| --- | --- |
| `.github/workflows/commitlint.yaml` | `contents: read`, `pull-requests: read` |

- `contents: read`: `actions/checkout` 用
- `pull-requests: read`: `wagoid/commitlint-github-action` が PR コミット一覧を GitHub API 経由で取得するため

## Test plan

- [ ] CI (commitlint) が PR 上で成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)