### PR TITLE
ci: introduce actionlint with automated GitHub Actions execution

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,4 +1,5 @@
 name: setup
+description: Setup mise, node, and pnpm.
 
 runs:
   using: composite

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,0 +1,36 @@
+name: Lint GitHub Actions
+
+on:
+  pull_request:
+    types:
+      - synchronize
+      - opened
+      - reopened
+    paths:
+      - '.github/**'
+  push:
+    branches:
+      - main
+      - 'releases/*'
+    paths:
+      - '.github/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # Not using ./.github/actions/setup: actionlint is a standalone binary
+      # and the composite's pnpm install is unnecessary here.
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+      - name: Run actionlint
+        run: actionlint -color

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,4 @@
 [tools]
+actionlint = "1.7.12"
 node = "24.15.0"
 pnpm = "9.15.9"


### PR DESCRIPTION
## Summary

- Introduce actionlint as a CI quality gate for `.github/workflows/*.yaml` and composite actions.
- Manage the binary via mise (`actionlint = "1.7.12"`) so local and CI use the same version.
- Add `.github/workflows/actionlint.yaml` that runs on PRs and pushes to `main` / `releases/*` when `.github/**` files change. Reuses the existing `actions/checkout` and `jdx/mise-action` SHA pins from the rest of the repo.
- Add a `description:` field to `.github/actions/setup/action.yaml` — actionlint flags its absence as `description is required in metadata of "setup" action`.

The workflow installs `jdx/mise-action` directly rather than reusing `./.github/actions/setup` because actionlint is a standalone Go binary that doesn't need `pnpm install`.

## References

- n/a
