### PR TITLE
chore(lefthook): include flat dist files in code-hook exclude

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -4,6 +4,7 @@ pre-commit:
     code:
       glob: '*.{js,ts}'
       exclude:
+        - dist/*
         - dist/**/*
       run: pnpm exec oxfmt --write {staged_files} && pnpm exec oxlint --max-warnings=0 {staged_files}
       stage_fixed: true


### PR DESCRIPTION
## Summary

- `#112` で追加した `dist/**/*` glob は flat dist (深さ1) の `dist/index.js` 等にマッチしなかったため、code hook の oxfmt が引き続き `dist/index.js` を渡されて exit 2 となっていた。
- `dist/*` を追加して dist 直下のファイルも除外。`dist/**/*` も残しサブディレクトリ対応。
- 影響: dist/ 再生成 commit が pre-commit hook で通るようになる。

## Test plan

- [x] lefthook の glob/exclude semantics に従い `dist/index.js` 等の flat dist が除外されること
