### PR TITLE
chore: enforce pnpm minimumReleaseAge to align with renovate

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,5 @@ packages:
 allowBuilds:
   esbuild: true
   lefthook: true
+# 7 days in minutes; align with renovate.json5 minimumReleaseAge: '7 days'.
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary

Add pnpm's `minimumReleaseAge: 10080` (7 days, in minutes) to `pnpm-workspace.yaml` so pnpm itself refuses to install package versions younger than the same 7-day window `renovate.json5` already enforces for PR creation (`minimumReleaseAge: '7 days'`).

This closes a gap where renovate gates PRs but local / CI `pnpm install` (e.g. lockfile regeneration or adding a new dependency) could still pull just-published versions, leaving supply-chain risk on the table.

- `pnpm` is pinned to `11.0.9` via `mise.toml`, which supports `minimumReleaseAge` (introduced in pnpm 10.16).
- The pnpm key is a numeric minute value (10080 = 7 × 24 × 60); the comment cross-references `renovate.json5` to keep both values in sync if either is changed.
- No effect on existing `pnpm install --frozen-lockfile` (verified locally).

## References

- n/a
