### PR TITLE
chore(ci): introduce automerge-gate to aggregate path-filtered checks

### DIFF
--- a/.github/workflows/automerge-gate.yaml
+++ b/.github/workflows/automerge-gate.yaml
@@ -1,0 +1,37 @@
+name: automerge-gate
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - auto_merge_enabled
+  pull_request_review:
+    types:
+      - submitted
+
+permissions:
+  contents: read
+  checks: read
+  actions: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  all-passed:
+    if: >-
+      github.event_name != 'pull_request_review' ||
+      github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: pkgdeps/automerge-gate@1b731ae7137b3b0c37c09bd40df73b2a34a5abaa # v4.1.0
+        with:
+          gate-mode: 'public'
+          ignore-checks: |
+            dogfood
+            publish


### PR DESCRIPTION
## Summary
- Add `.github/workflows/automerge-gate.yaml` using `pkgdeps/automerge-gate@v4.1.0` (SHA-pinned) in **public** mode so the gate's own check_run is the single required status.
- Filter `dogfood` and `publish` via `ignore-checks` — `dogfood` is `skipped` on PR events and `publish` only runs on `main`-push, so they should not contribute to the aggregated verdict.
- Public mode is preferred over the README's private-mode example because this repo allows manual self-merges (no review-required ruleset). In private mode the gate stays unposted unless auto-merge or an approving review fires, which would block manual merges. Public mode keeps the gate always-running and fork-friendly.

## Why
Currently the branch ruleset requires only `build_and_test` + `commitlint`, so `actionlint` (path-filtered to `.github/**`) is not required. If actionlint runs and fails, auto-merge still proceeds; if we add it to required, PRs that don't touch `.github/**` would block forever waiting on a check that never runs. The gate solves both: it waits only for checks that actually ran.

## Follow-up (operational, NOT in this PR)
After this PR merges, swap the branch ruleset's required status checks from `build_and_test` + `commitlint` to a single `all-passed` entry:

```bash
gh api repos/knowledge-work/command-action/rulesets/1512870 \
  --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks'
# then PUT updated payload with required_status_checks = [{"context":"all-passed","integration_id":15368}]
```

Run the swap immediately after merge so in-flight PRs only need a rebase.

## Test plan
- [ ] `actionlint .github/workflows/automerge-gate.yaml` passes
- [ ] `pnpm format:check` clean
- [ ] On this PR, the new `all-passed` job appears in the checks list and finishes with `success` conclusion after the other workflows complete
- [ ] `dogfood` (skipped) and `publish` (absent) do not affect the gate's verdict
