### PR TITLE
chore: verify automerge-gate behavior for paths-filtered checks (DO NOT MERGE)

### DIFF
--- a/_verify-gate.md
+++ b/_verify-gate.md
@@ -1,0 +1,14 @@
+# automerge-gate behavior verification (TEMPORARY)
+
+This file exists only to produce a non-`.github/**` diff so that the
+`actionlint` workflow's `paths` filter excludes this PR.
+
+The associated PR is intentionally never merged. It is closed after
+observing that:
+
+- `actionlint` does NOT appear in `gh pr checks` (paths filter skipped it).
+- `all-passed` (the automerge-gate job) still completes with SUCCESS,
+  proving the gate ignores absent path-filtered workflows rather than
+  blocking on them.
+
+Delete this file by closing the PR and deleting the branch.


### PR DESCRIPTION
## Summary (temporary / verification-only — DO NOT MERGE)

Probes the `automerge-gate` workflow added in #121 against a diff that does **not** touch `.github/**`. The `actionlint` workflow's `paths: ['.github/**']` filter should exclude it, leaving the check set as `build_and_test` + `commitlint` + `registered` + `all-passed` (+ `dogfood`/`publish` skipped and ignored).

Expected observation:

- `actionlint` does NOT appear in `gh pr checks`.
- `all-passed` (the gate) still completes with `SUCCESS`, proving that path-filtered workflows that legitimately did not run are not waited-on or blocking.

This PR is closed without merging once the observation is captured.

## Test plan
- [ ] `gh pr checks <PR>` shows no `actionlint` entry
- [ ] `gh pr checks <PR>` shows `all-passed: SUCCESS`
- [ ] Close the PR + delete the branch after observation
