### PR TITLE
ci: replace wagoid commitlint action with locally installed CLI

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -18,4 +18,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
+      - uses: ./.github/actions/setup
+
+      - name: Commitlint
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: pnpm exec commitlint --from="$BASE_SHA" --to="$HEAD_SHA" --verbose


### PR DESCRIPTION
## Summary

- Drop the third-party `wagoid/commitlint-github-action` from `.github/workflows/commitlint.yaml` and run the already installed `@commitlint/cli` directly, mirroring the existing `ci.yaml` pattern (`actions/checkout` + `./.github/actions/setup` + `pnpm <step>`) and the local lefthook usage (`pnpm exec commitlint --edit {1}`).
- The commit range is derived from `pull_request.base.sha` / `head.sha`, passed via `env:` to avoid inline `${{ }}` expansion in `run:` (defense-in-depth against expression injection).
- `fetch-depth: 0` is preserved so the base SHA is reachable. No changes to triggers, permissions, job name, or runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
