### PR TITLE
ci: add zizmor audit and consolidate gh-actions checks

### DIFF
--- a/.github/workflows/audit-actions.yaml
+++ b/.github/workflows/audit-actions.yaml
@@ -1,4 +1,4 @@
-name: Lint GitHub Actions
+name: Audit GitHub Actions
 
 on:
   pull_request:
@@ -8,12 +8,14 @@ on:
       - reopened
     paths:
       - '.github/**'
+      - 'action.yaml'
   push:
     branches:
       - main
       - 'releases/*'
     paths:
       - '.github/**'
+      - 'action.yaml'
 
 permissions:
   contents: read
@@ -27,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup
         with:
@@ -34,3 +38,17 @@ jobs:
 
       - name: Run actionlint
         run: actionlint -color
+
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup
+        with:
+          install: 'false'
+
+      - name: Run zizmor
+        run: zizmor .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: ./.github/actions/setup
 
@@ -38,6 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,6 +35,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup
 

--- a/mise.toml
+++ b/mise.toml
@@ -2,3 +2,4 @@
 actionlint = "1.7.12"
 node = "24.15.0"
 pnpm = "11.0.9"
+zizmor = "1.25.2"


### PR DESCRIPTION
## Summary

Introduce [`zizmor`](https://github.com/zizmorcore/zizmor) as a second static analyzer for GitHub Actions workflows and composite actions, focused on security-oriented checks (credential persistence, code injection, over-privileged `GITHUB_TOKEN`, etc.) that complement what `actionlint` already covers syntactically.

- Add `zizmor = "1.25.2"` to `mise.toml` so the runner picks it up via the existing `setup` composite action.
- Consolidate the prior `actionlint.yaml` workflow with the new `zizmor` audit into a single `audit-actions.yaml` workflow with two parallel jobs (`actionlint`, `zizmor`), sharing trigger, permissions, and concurrency declarations. The trigger now also watches `action.yaml` so the JS action manifest is covered by zizmor.
- Resolve the four `artipacked` warnings zizmor raised at baseline by adding `persist-credentials: false` to every `actions/checkout` step that lacked it across `audit-actions.yaml`, `ci.yaml` (commitlint + build_and_test), and `e2e.yaml` (dogfood). The `publish` job already had it.

Local verification:

```
$ mise install
mise all tools are installed

$ mise exec -- actionlint -color
(no output, exit 0)

$ mise exec -- zizmor .
 INFO zizmor: 🌈 zizmor v1.25.2
 INFO audit: zizmor: 🌈 completed ./.github/actions/setup/action.yaml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/audit-actions.yaml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/automerge-gate.yaml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/ci.yaml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/e2e.yaml
 INFO audit: zizmor: 🌈 completed ./action.yaml
No findings to report. Good job! (12 suppressed)
```

SARIF upload to GitHub Code Scanning is intentionally out of scope for this PR — fork PRs downgrade `security-events: write` to read-only, which would need an extra guard. The current console-output + non-zero exit code is enough to block merges on new findings.

## References

- n/a
